### PR TITLE
Bump minimum numpy and Python versions (#622)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.11", "3.12", "3.13"]
         # macos-12 is an intel runner, macos-14 is a arm64 runner
         platform: [ubuntu-latest, windows-latest, macos-12, macos-14]
 
@@ -68,12 +68,12 @@ jobs:
         shell: "bash -l {0}"
         run: |
             conda activate env
-            python -m pip install -v pcodec
+            python -m pip install -v ".[pcodec]"
 
 
       # This is used to test with zfpy, which does not yet support numpy 2.0
       - name: Install older numpy and zfpy
-        if: matrix.python-version == '3.10'
+        if: matrix.python-version == '3.11'
         shell: "bash -l {0}"
         run: |
           conda activate env

--- a/.github/workflows/wheel.yaml
+++ b/.github/workflows/wheel.yaml
@@ -17,7 +17,7 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-12, macos-14]
     env:
       CIBW_TEST_COMMAND: python -c "import numcodecs"
-      CIBW_BUILD: "cp310-* cp311-* cp312-* cp313-*"
+      CIBW_BUILD: "cp311-* cp312-* cp313-*"
       CIBW_SKIP: "pp* *-musllinux_* *win32 *_i686 *_s390x"
       # note: CIBW_ENVIRONMENT is now set in pyproject.toml
 
@@ -44,7 +44,7 @@ jobs:
       - uses: actions/setup-python@v5
         name: Install Python
         with:
-          python-version: "3.10"
+          python-version: "3.11"
 
       - name: Build sdist
         run: pipx run build --sdist

--- a/docs/release.rst
+++ b/docs/release.rst
@@ -25,6 +25,13 @@ Enhancements
 * Add Crc32c checksum codec
   By :user:`Norman Rzepka <normanrz>`, :issue:`613`.
 
+Maintenance
+~~~~~~~~~~~
+* The minimum supported Python version is now Python 3.11.
+  By :user:`David Stansby <dstansby>`, :issue:`622`
+* The minimum supported numpy version is now 1.24.
+  By :user:`David Stansby <dstansby>`, :issue:`622`
+
 .. _release_0.13.1:
 
 0.13.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ requires = [
     "setuptools-scm[toml]>=6.2",
     "Cython",
     "py-cpuinfo",
-    "numpy",
+    "numpy>2",
 ]
 build-backend = "setuptools.build_meta"
 
@@ -15,9 +15,9 @@ A Python package providing buffer compression and transformation codecs \
 for use in data storage and communication applications."""
 readme =  "README.rst"
 dependencies = [
-    "numpy>=1.7",
+    "numpy>=1.23",
 ]
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 dynamic = [
   "version",
 ]
@@ -68,7 +68,7 @@ zfpy = [
     "numpy<2.0.0",
 ]
 pcodec = [
-    "pcodec>=0.2.0",
+    "pcodec>=0.2,<0.3",
 ]
 crc32c = [
     "crc32c>=2.7",


### PR DESCRIPTION
* Bump minimum numpy and Python versions

* Fix issue numbere

* Bump build system numpy requirement

* Pin pcodec

* Fix pcodec install

[Description of PR]

TODO:

- [ ] Unit tests and/or doctests in docstrings
- [ ] Tests pass locally
- [ ] Docstrings and API docs for any new/modified user-facing classes and functions
- [ ] Changes documented in docs/release.rst
- [ ] Docs build locally
- [ ] GitHub Actions CI passes
- [ ] Test coverage to 100% (Codecov passes)
